### PR TITLE
Compass should be invalidated when insets change

### DIFF
--- a/src/com/esri/arcgisruntime/toolkit/skins/CompassSkin.java
+++ b/src/com/esri/arcgisruntime/toolkit/skins/CompassSkin.java
@@ -67,6 +67,7 @@ public final class CompassSkin extends SkinBase<Compass> {
 
     control.widthProperty().addListener(observable -> invalid = true);
     control.heightProperty().addListener(observable -> invalid = true);
+    control.insetsProperty().addListener(observable -> invalid = true);
 
     // bind to the control's heading property
     stackPane.rotateProperty().bind(control.headingProperty().negate());


### PR DESCRIPTION
Compass draws incorrectly when border or padding is changed e.g.
Before any padding it looks like
![image](https://user-images.githubusercontent.com/5682200/36981423-087bf72c-2085-11e8-8491-503274582475.png)
then with padding set as - `compass.setPadding(new Insets(10.0, 20.0, 30.0, 40.0)` it looks like
![image](https://user-images.githubusercontent.com/5682200/36981349-dcf54c48-2084-11e8-9846-005ea6f4576c.png)
but should look like
![image](https://user-images.githubusercontent.com/5682200/36981386-f6783f72-2084-11e8-8703-04eece32b07b.png)
Fix is to invalidate the compass when the insets property changes. The insets property changes when padding or border changes.
