### PR TITLE
specify archives base name for jar and javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ apply plugin: 'java-library'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 
+archivesBaseName = "arcgis-java-toolkit"
+
 idea.module.downloadJavadoc = true
 eclipse.classpath.downloadJavadoc = true
 
@@ -13,7 +15,7 @@ compileJava.options.encoding = 'UTF-8'
 repositories {
   jcenter()
   maven {
-    url 'https://esri.bintray.com/arcgis'
+    url = 'https://esri.bintray.com/arcgis'
   }
 }
 


### PR DESCRIPTION
sets archives base name to `arcgis-java-toolkit` instead of the project name