### PR TITLE
Add named argument so scalebar can be used in FXML

### DIFF
--- a/src/main/java/com/esri/arcgisruntime/toolkit/Scalebar.java
+++ b/src/main/java/com/esri/arcgisruntime/toolkit/Scalebar.java
@@ -23,6 +23,7 @@ import com.esri.arcgisruntime.toolkit.skins.BarScalebarSkin;
 import com.esri.arcgisruntime.toolkit.skins.DualUnitScalebarSkin;
 import com.esri.arcgisruntime.toolkit.skins.GraduatedLineScalebarSkin;
 import com.esri.arcgisruntime.toolkit.skins.LineScaleBarSkin;
+import javafx.beans.NamedArg;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.HPos;
@@ -103,7 +104,7 @@ public final class Scalebar extends Control {
    * @throws NullPointerException if map view is null
    * @since 100.2.1
    */
-  public Scalebar(MapView mapView) {
+  public Scalebar(@NamedArg("mapView") MapView mapView) {
     this(mapView, SkinStyle.ALTERNATING_BAR, HPos.CENTER);
   }
 


### PR DESCRIPTION
Add named argument to scale bar constructor so it can be used from FXML e.g.
```
<MapView fx:id="mapView" prefHeight="400" prefWidth="400"/>
<Scalebar fx:id="scalebar" mapView="$mapView"/>
```
without this it isn't possible to use the scale bar in FXML as it has no no-arg constructor.