### PR TITLE
Natives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,14 @@ sourceSets {
   }
 }
 
+configurations {
+  natives
+}
+
 dependencies {
   implementation "com.esri.arcgisruntime:arcgis-java:100.7.0"
+  natives "com.esri.arcgisruntime:arcgis-java-jnilibs:100.7.0"
+  natives "com.esri.arcgisruntime:arcgis-java-resources:100.7.0"
   implementation "org.openjfx:javafx-base:11:$platform"
   implementation "org.openjfx:javafx-graphics:11:$platform"
   implementation "org.openjfx:javafx-controls:11:$platform"
@@ -56,11 +62,24 @@ dependencies {
   integrationTestImplementation "org.hamcrest:hamcrest:2.1"
 }
 
+task copyNatives(type: Copy) {
+  description = "Copies the arcgis native libraries into USER_HOME/.arcgis for development."
+  group = "build"
+  configurations.natives.asFileTree.each {
+    from(zipTree(it))
+  }
+  into "${System.properties.getProperty("user.home")}/.arcgis/100.7.0"
+}
+
 task integrationTest(type: Test) {
   description = 'Runs the integration tests.'
   group = 'verification'
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
+}
+
+tasks.withType(Test.class) {
+  dependsOn copyNatives
 }
 
 task javadocJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ configurations {
 
 dependencies {
   implementation "com.esri.arcgisruntime:arcgis-java:$version"
-  natives "com.esri.arcgisruntime:arcgis-java-jnilibs:100.7.0"
-  natives "com.esri.arcgisruntime:arcgis-java-resources:100.7.0"
+  natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$version"
+  natives "com.esri.arcgisruntime:arcgis-java-resources:$version"
   implementation "org.openjfx:javafx-base:11:$platform"
   implementation "org.openjfx:javafx-graphics:11:$platform"
   implementation "org.openjfx:javafx-controls:11:$platform"
@@ -68,7 +68,7 @@ task copyNatives(type: Copy) {
   configurations.natives.asFileTree.each {
     from(zipTree(it))
   }
-  into "${System.properties.getProperty("user.home")}/.arcgis/100.7.0"
+  into "${System.properties.getProperty("user.home")}/.arcgis/$version"
 }
 
 task integrationTest(type: Test) {


### PR DESCRIPTION
Adds task to download native libraries via Gradle before running tests. Branched off of https://github.com/Esri/arcgis-runtime-toolkit-java/pull/30.