### PR TITLE
Update build.gradle script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ repositories {
     maven {
         url 'https://esri.jfrog.io/artifactory/arcgis'
     }
-    maven {
-        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
-    }
 }
 
 configurations {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plugins {
 // Replace with version number of ArcGIS SDK you are using in your app, such as:
 // arcgisVersion = '100.11.0'. See table below for SDK Versions that support the toolkit.
 ext {
-  arcgisVersion = '100.2.1'
+  arcgisVersion = '100.11.0'
 }
 
 javafx {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The toolkit library jar is hosted on https://esri.jfrog.io/artifactory/arcgis.
 To add the dependency to your project using Gradle:
 ```groovy
 plugins {
-    'application'
+    id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 // Replace with version number of ArcGIS SDK you are using in your app, such as:
@@ -24,18 +25,33 @@ ext {
   arcgisVersion = '100.2.1'
 }
 
+javafx {
+    version = "11.0.2"
+    modules = [ 'javafx.controls' ]
+}
+
 compileJava.options.encoding = 'UTF-8'
 
 // Toolkit and Runtime SDK repository
 repositories {
-  maven {
-      url 'https://esri.jfrog.io/artifactory/arcgis'
-  }
+    jcenter()
+    maven {
+        url 'https://esri.jfrog.io/artifactory/arcgis'
+    }
+    maven {
+        url 'https://olympus.esri.com/artifactory/arcgisruntime-repo'
+    }
+}
+
+configurations {
+    natives
 }
 
 dependencies {
-  implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
-  implementation "com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
+    natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
+    implementation 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,23 +14,19 @@ The toolkit library jar is hosted on https://esri.jfrog.io/artifactory/arcgis.
 
 To add the dependency to your project using Gradle:
 ```groovy
-apply plugin: 'application'
-
-// Runtime SDK dependency
-apply plugin: 'com.esri.arcgisruntime.java'
-buildscript {
-    repositories {
-        maven {
-            url 'https://esri.jfrog.io/artifactory/arcgis'
-        }
-    }
-    dependencies {
-        classpath 'com.esri.arcgisruntime:gradle-arcgis-java-plugin:1.0.0'
-    }
+plugins {
+    'application'
 }
-arcgis.version = '100.2.1'
 
-// Toolkit dependency
+// Replace with version number of ArcGIS SDK you are using in your app, such as:
+// arcgisVersion = '100.11.0'. See table below for SDK Versions that support the toolkit.
+ext {
+  arcgisVersion = '100.2.1'
+}
+
+compileJava.options.encoding = 'UTF-8'
+
+// Toolkit and Runtime SDK repository
 repositories {
   maven {
       url 'https://esri.jfrog.io/artifactory/arcgis'
@@ -38,21 +34,22 @@ repositories {
 }
 
 dependencies {
-  compile 'com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1'
+  implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+  implementation "com.esri.arcgisruntime:arcgis-java-toolkit:100.2.1"
 }
 ```
 
 ## Requirements
 
 The toolkit requires the ArcGIS Runtime SDK for Java. Refer to the Instructions section above if you are using Gradle.
-See [the guide](https://developers.arcgis.com/java/latest/guide/install-the-sdk.htm) for complete instructions and
+See [the guide](https://developers.arcgis.com/java/install-and-set-up/) for complete instructions and
 other options for installing the SDK.
 
 The following table shows which versions of the SDK are compatible with the toolkit:
 
 |  SDK Version  |  Toolkit Version  |
 | --- | --- |
-| 100.2.1 | 100.2.1 |
+| 100.2.1 or later | 100.2.1 |
 
 ## Resources
 


### PR DESCRIPTION
Multiple changes to README.md:
- remove arcgis java plugin for Gradle
- replace `apply plugin` lines with the `plugins {}` block
- remove `buildscript` block
- replace `arcgis.version = 100.2.1` with an `ext` property named `arcgisVersion`
- add comment about ability to replace `100.2.1` with latest Runtime version
- add `compileJava.options.encoding = 'UTF-8'`
- in `dependencies` block replace `compile` with `implementation`
- in `dependencies` block add the `arcgis-java` dependency to the `implementation' configuration
- fix link to Install the SDK page in Java guide on developers.arcgis.com
- update Requirements table for `SDK Version` from `100.2.1` to `100.2.1 and later`

#### Related issue
- https://github.com/ArcGIS/afd-native-apis-doc/issues/575