### PR TITLE
Basemaps update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ The following table shows which versions of the SDK are compatible with the tool
 |----------------------------------------------------------| --- |
 | 100.2.1 or later (including the latest 100.13.0 release) | 100.2.1 |
 
+### API Key requirements
+
+Some of the toolkit components utilize ArcGIS Platform services which require an API key. Refer to the 'Access services' section of the 
+[Get Started guide](https://developers.arcgis.com/java/get-started/#3-access-services-and-content-with-an-api-key) 
+for more information. Help with how to set your API key can be found in the 
+[Developer Guide tutorials](https://developers.arcgis.com/java/maps-2d/tutorials/display-a-map/#set-your-api-key)
+and [Java Samples Repository](https://github.com/Esri/arcgis-runtime-samples-java). If a toolkit component requires an API
+key, this will be indicated within the JavaDoc for the component.
+
 ### Latest update
 
 A new release of the toolkit will be coming with the 100.14.0 release of the ArcGIS Runtime SDK for Java (due Spring 2022). The toolkit jar will be made available via our maven repository on jfrog. Additional information will be provided at that time, but this will include new toolkit components as well as updates and improvements to existing components.

--- a/src/main/java/com/esri/arcgisruntime/toolkit/OverviewMap.java
+++ b/src/main/java/com/esri/arcgisruntime/toolkit/OverviewMap.java
@@ -19,6 +19,7 @@ package com.esri.arcgisruntime.toolkit;
 import java.util.Objects;
 
 import com.esri.arcgisruntime.mapping.Basemap;
+import com.esri.arcgisruntime.mapping.BasemapStyle;
 import com.esri.arcgisruntime.mapping.view.GeoView;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.ColorUtil;
@@ -39,6 +40,10 @@ import javafx.scene.paint.Color;
 /**
  * An overview map control that indicates the viewpoint of another map or scene view.
  *
+ * Note: By default, the OverviewMap will attempt to use an ArcGIS Topographic basemap, which requires an
+ * <a href="https://developers.arcgis.com/java/get-started/#3-access-services-and-content-with-an-api-key">API key</a>
+ * to access.
+ *
  * @since 100.2.1
  */
 public class OverviewMap extends Control {
@@ -57,12 +62,16 @@ public class OverviewMap extends Control {
   /**
    * Creates an overview map for a GeoView using default values for the basemap and indicator symbol.
    *
+   * Note: By default, the OverviewMap will attempt to use an ArcGIS Topographic basemap, which requires an
+   * <a href="https://developers.arcgis.com/java/get-started/#3-access-services-and-content-with-an-api-key">API key</a>
+   * to access.
+   *
    * @param geoView the GeoView to connect to this overview map
    * @throws NullPointerException if geoView is null
    * @since 100.2.1
    */
   public OverviewMap(GeoView geoView) {
-    this(geoView, Basemap.createTopographic(), geoView instanceof MapView ? FILL_SYMBOL : MARKER_SYMBOL);
+    this(geoView, new Basemap(BasemapStyle.ARCGIS_TOPOGRAPHIC), geoView instanceof MapView ? FILL_SYMBOL : MARKER_SYMBOL);
   }
 
   /**
@@ -81,6 +90,10 @@ public class OverviewMap extends Control {
   /**
    * Creates an overview map for a GeoView using a default basemap.
    *
+   * Note: By default, the OverviewMap will attempt to use an ArcGIS Topographic basemap, which requires an
+   * <a href="https://developers.arcgis.com/java/get-started/#3-access-services-and-content-with-an-api-key">API key</a>
+   * to access.
+   *
    * @param geoView the GeoView to connect to this overview map
    * @param symbol the symbol to use, for a map view use a fill symbol and for a scene view use a marker symbol
    * @throws NullPointerException if geoView is null
@@ -88,7 +101,7 @@ public class OverviewMap extends Control {
    * @since 100.2.1
    */
   public OverviewMap(GeoView geoView, Symbol symbol) {
-    this(geoView, Basemap.createTopographic(), symbol);
+    this(geoView, new Basemap(BasemapStyle.ARCGIS_TOPOGRAPHIC), symbol);
   }
 
   /**


### PR DESCRIPTION
- `Basemap.createTopographic()` is deprecated at 100.14.0 and is used in the OverviewMap default constructors. This PR replaces these instances with the new Basemap Styles ahead of the release.
- As the new default will require an API key, documentation has been added to support this.